### PR TITLE
Change CONTROL RESETLOOP to CONTROL OTHERWISE

### DIFF
--- a/src/bespokelang/exceptions.py
+++ b/src/bespokelang/exceptions.py
@@ -4,11 +4,11 @@ __all__ = [
     "TokenizerException", "ExpectedSpecifier", "ImproperSizedNumber",
     "UnterminatedCommentBody", "UnterminatedCommentSignature",
 
-    "ParserException", "UnexpectedContinuedNumber",
+    "ParserException", "UnexpectedContinuedNumber", "UnexpectedElse",
     "UnexpectedEndOfBlock",
 
     "RuntimeException", "InvalidNumberInput", "InvalidStackArgument",
-    "StackUnderflow", "UndefinedFunction", "UnexpectedLoopManipulation",
+    "StackUnderflow", "UndefinedFunction", "UnexpectedBreak",
     "UnexpectedReturn",
 ]
 
@@ -66,6 +66,9 @@ class ParserException(BespokeException):
 class UnexpectedContinuedNumber(ParserException):
     """Unexpected CONTINUED number."""
 
+class UnexpectedElse(ParserException):
+    """Unexpected ELSE command."""
+
 class UnexpectedEndOfBlock(ParserException):
     """Unexpected end of block."""
 
@@ -85,8 +88,8 @@ class StackUnderflow(RuntimeException):
 class UndefinedFunction(RuntimeException):
     """Undefined function."""
 
-class UnexpectedLoopManipulation(RuntimeException):
-    """Loop manipulation used outside of a loop."""
+class UnexpectedBreak(RuntimeException):
+    """Unexpected B command."""
 
 class UnexpectedReturn(RuntimeException):
     """Unexpected RETURN command."""

--- a/src/bespokelang/exceptions.py
+++ b/src/bespokelang/exceptions.py
@@ -4,8 +4,8 @@ __all__ = [
     "TokenizerException", "ExpectedSpecifier", "ImproperSizedNumber",
     "UnterminatedCommentBody", "UnterminatedCommentSignature",
 
-    "ParserException", "UnexpectedContinuedNumber", "UnexpectedElse",
-    "UnexpectedEndOfBlock",
+    "ParserException", "UnexpectedContinuedNumber",
+    "UnexpectedEndOfBlock", "UnexpectedOtherwise",
 
     "RuntimeException", "InvalidNumberInput", "InvalidStackArgument",
     "StackUnderflow", "UndefinedFunction", "UnexpectedBreak",
@@ -66,11 +66,11 @@ class ParserException(BespokeException):
 class UnexpectedContinuedNumber(ParserException):
     """Unexpected CONTINUED number."""
 
-class UnexpectedElse(ParserException):
-    """Unexpected ELSE command."""
-
 class UnexpectedEndOfBlock(ParserException):
     """Unexpected end of block."""
+
+class UnexpectedOtherwise(ParserException):
+    """Unexpected OTHERWISE command."""
 
 
 class RuntimeException(BespokeException):

--- a/src/bespokelang/interpreter.py
+++ b/src/bespokelang/interpreter.py
@@ -388,7 +388,7 @@ class BespokeInterpreter:
                 # CONTROL OTHERWISE
                 case Token("7", "9", _):
                     if not block or not isinstance(block[0], Token):
-                        raise UnexpectedElse
+                        raise UnexpectedOtherwise
 
                     first_token = category, command, args = block[0]
                     # CONTROL OTHERWISE is only valid as the last item
@@ -397,7 +397,7 @@ class BespokeInterpreter:
                         case Token("7", "2", _):
                             pass
                         case _:
-                            raise UnexpectedElse
+                            raise UnexpectedOtherwise
 
                     # This command "closes" the block, similarly to
                     # CONTROL END

--- a/src/bespokelang/interpreter.py
+++ b/src/bespokelang/interpreter.py
@@ -102,7 +102,7 @@ def int_nth_root(x: int, n: int):
         raise ValueError("n must be positive")
     if not x:
         return 0
-    if x <= 0:
+    if x < 0:
         raise ValueError("x must be nonnegative")
 
     q, r = x + 1, x


### PR DESCRIPTION
Because `CONTROL RESETLOOP` has very few situations where it would be useful, and an "else block" for `CONTROL IF` has many situations where it would be useful, I've decided to change the `CONTROL RESETLOOP` command to `CONTROL OTHERWISE`.